### PR TITLE
Native android notifications support

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,8 +120,9 @@ The builtins are:
 | notifier      | Uses terminal-notifier on OS X, if it is on the PATH               |
 | osx-notifier  | Native OSX notification using AppleScript                          |
 | toaster       | Use the toast notification system                                  |
-| x11           | Changes the urgency property of the window in the X Window System
-| termux        | Use `termux-notification` from the Termux API                     |
+| x11           | Changes the urgency property of the window in the X Window System  |
+| termux        | Use `termux-notification` from the Termux API                      |
+| android-notifications | Use `android-notifications-notify` from the native Emacs Android port |
 
 # Defining new styles
 

--- a/alert.el
+++ b/alert.el
@@ -136,6 +136,7 @@
 ;;   toaster       - Use the toast notification system
 ;;   x11           - Changes the urgency property of the window in the X Window System
 ;;   termux        - Use termux-notification from the Termux API
+;;   android-notifications - Use android-notifications-notify from the native Emacs Android port
 ;;
 ;; * Defining new styles
 ;;
@@ -986,6 +987,26 @@ This is found at https://github.com/nels-o/toaster."
 
 (alert-define-style 'toaster :title "Notify using Toaster"
                     :notifier #'alert-toaster-notify)
+
+(defun alert-android-notifications-notify (info)
+  "Send notifications using android-notifications-notify.
+android-notifications-notify is a built-in function in the native Emacs
+Android port."
+  (let ((title (or (plist-get info :title) "Android Notifications Alert"))
+        (body (or (plist-get info :message) ""))
+        (urgency (cdr (assq (plist-get info :severity)
+                            alert-notifications-priorities)))
+        (icon (or (plist-get info :icon) alert-default-icon))
+        (replaces-id (gethash (plist-get info :id) alert-notifications-ids)))
+    (android-notifications-notify
+     :title title
+     :body body
+     :urgency urgency
+     :icon icon
+     :replaces-id replaces-id)))
+
+(alert-define-style 'android-notifications :title "Android Notifications"
+                    :notifier #'alert-android-notifications-notify)
 
 (defcustom alert-termux-command (executable-find "termux-notification")
   "Path to the termux-notification command.


### PR DESCRIPTION
This MR adds support for `android-notifications-notify` to be used for the [native Emacs Android port](https://sourceforge.net/projects/android-ports-for-gnu-emacs/).

From the documentation of `android-notifications-notify`:

```
android-notifications-notify is a built-in function in ‘C source
code’.

(android-notifications-notify &rest ARGS)

Display a desktop notification.
ARGS must contain keywords followed by values.  Each of the following
keywords is understood:

  :title        The notification title.
  :body         The notification body.
  :replaces-id  The ID of a previous notification to supersede.
  :group        The notification group, or nil.
  :urgency      One of the symbols ‘low’, ‘normal’ or ‘critical’,
                defining the importance of the notification group.
  :icon         The name of a drawable resource to display as the
                notification’s icon.

The notification group and urgency are ignored on Android 7.1 and
earlier versions of Android.  Outside such older systems, it
identifies a category that will be displayed in the system Settings
menu.  The urgency provided always extends to affect all notifications
displayed within that category.  If the group is not provided, it
defaults to the string "Desktop Notifications".

The provided icon should be the name of a "drawable resource" present
within the "android.R.drawable" class designating an icon with a
transparent background.  If no icon is provided (or the icon is absent
from this system), it defaults to "ic_dialog_alert".

When the system is running Android 13 or later, notifications sent
will be silently disregarded unless permission to display
notifications is expressly granted from the "App Info" settings panel
corresponding to Emacs.

A title and body must be supplied.  Value is an integer (fixnum or
bignum) uniquely designating the notification displayed, which may
subsequently be specified as the ‘:replaces-id’ of another call to
this function.
```

Example test:

![Screenshot_20240106-125414](https://github.com/jwiegley/alert/assets/23484273/ab37d8cd-4323-45ef-8f45-f54456fba8cc)